### PR TITLE
Fix crash on some specific devices while executing getprop

### DIFF
--- a/RomChecker/src/main/java/com/walkud/rom/checker/utils/SystemPropertyUtil.java
+++ b/RomChecker/src/main/java/com/walkud/rom/checker/utils/SystemPropertyUtil.java
@@ -50,7 +50,8 @@ public class SystemPropertyUtil {
         try {
             Process p = Runtime.getRuntime().exec("getprop");
             properties.load(p.getInputStream());
-        } catch (IOException e) {
+        } catch (Exception e) {
+            // Some devices may result in "IllegalArgumentException Invalid Unicode sequence: illegal character"
             e.printStackTrace();
         }
         return properties;


### PR DESCRIPTION
根据闪退日志，一些设备 (如 PHICOMM E1030 ) 在 getprop 的时候会出现闪退

简单日志如下

```
java.lang.IllegalArgumentException: Invalid Unicode sequence: illegal character
    at java.util.Properties.load(Properties.java:308)
    at java.util.Properties.load(Properties.java:248)
    at com.walkud.rom.checker.utils.SystemPropertyUtil.a(SourceFile:52)
    at com.walkud.rom.checker.utils.RomProperties.<init>(SourceFile:17)
    at com.walkud.rom.checker.RomIdentifier.b(SourceFile:104)
    at com.walkud.rom.checker.RomIdentifier.a(SourceFile:86)
    at com.walkud.rom.checker.RomIdentifier.b(SourceFile:73)
```
本 PR 对 try catch 的异常范围进行了扩大