### PR TITLE
Add support for HarmonyOS from huawei

### DIFF
--- a/RomChecker/src/main/java/com/walkud/rom/checker/Rom.java
+++ b/RomChecker/src/main/java/com/walkud/rom/checker/Rom.java
@@ -11,7 +11,8 @@ public enum Rom {
     //已适配
     MIUI("xiaomi"), // 小米
     Flyme("meizu"), // 魅族
-    EMUI("huawei"), // 华为
+    EMUI("huawei"), // 华为，EMUI
+    HarmonyOS("huawei"), // 华为，鸿蒙
     ColorOS("oppo"), // OPPO
     FuntouchOS("vivo"), // vivo
     SmartisanOS("smartisan"), // 锤子

--- a/RomChecker/src/main/java/com/walkud/rom/checker/RomIdentifier.java
+++ b/RomChecker/src/main/java/com/walkud/rom/checker/RomIdentifier.java
@@ -8,6 +8,7 @@ import com.walkud.rom.checker.cc.EuiChecker;
 import com.walkud.rom.checker.cc.FlymeChecker;
 import com.walkud.rom.checker.cc.FuntouchOsChecker;
 import com.walkud.rom.checker.cc.GoogleChecker;
+import com.walkud.rom.checker.cc.HarmonyOsChecker;
 import com.walkud.rom.checker.cc.LgeChecker;
 import com.walkud.rom.checker.cc.MiuiChecker;
 import com.walkud.rom.checker.cc.NubiaChecker;
@@ -46,7 +47,6 @@ public final class RomIdentifier {
     public static List<Checker> getChecker() {
         return Arrays.asList(
                 new MiuiChecker(),
-                new EmuiChecker(),
                 new ColorOsChecker(),
                 new FuntouchOsChecker(),
                 new SmartisanChecker(),
@@ -56,7 +56,9 @@ public final class RomIdentifier {
                 new SenseChecker(),
                 new LgeChecker(),
                 new GoogleChecker(),
-                new NubiaChecker()
+                new NubiaChecker(),
+                new HarmonyOsChecker(),
+                new EmuiChecker()
         );
     }
 

--- a/RomChecker/src/main/java/com/walkud/rom/checker/cc/HarmonyOsChecker.java
+++ b/RomChecker/src/main/java/com/walkud/rom/checker/cc/HarmonyOsChecker.java
@@ -36,7 +36,7 @@ public class HarmonyOsChecker extends Checker {
             Class clz = Class.forName("com.huawei.system.BuildEx");
             Method method = clz.getMethod("getOsBrand");
             return "harmony".equals(method.invoke(clz));
-        } catch (Exception e) {
+        } catch (Throwable e) {
             e.printStackTrace();
         }
         return false;
@@ -51,7 +51,7 @@ public class HarmonyOsChecker extends Checker {
             Class clz = Class.forName("ohos.system.version.SystemVersion");
             Method method = clz.getMethod("getVersion");
             return (String) method.invoke(clz);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             e.printStackTrace();
         }
         return "Unknown";

--- a/RomChecker/src/main/java/com/walkud/rom/checker/cc/HarmonyOsChecker.java
+++ b/RomChecker/src/main/java/com/walkud/rom/checker/cc/HarmonyOsChecker.java
@@ -1,0 +1,60 @@
+package com.walkud.rom.checker.cc;
+
+import com.walkud.rom.checker.Rom;
+import com.walkud.rom.checker.utils.RomProperties;
+
+import java.lang.reflect.Method;
+
+public class HarmonyOsChecker extends Checker {
+    
+    @Override
+    public Rom getRom() {
+        return Rom.HarmonyOS;
+    }
+    
+    @Override
+    public boolean checkBuildProp(RomProperties romProperties) {
+        String versionName = getHarmonyVersion();
+        
+        if (isHarmonyOS()) {
+            parseVersionCode(versionName);
+            getRom().setVersionName(versionName);
+            
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * 校验是否是鸿蒙系统
+     *
+     * @return true-鸿蒙系统
+     */
+    public static boolean isHarmonyOS() {
+        try {
+            Class clz = Class.forName("com.huawei.system.BuildEx");
+            Method method = clz.getMethod("getOsBrand");
+            return "harmony".equals(method.invoke(clz));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+    
+    /**
+     * 获取鸿蒙 ROM 的版本
+     * @return 版本
+     */
+    public static String getHarmonyVersion() {
+        try {
+            Class clz = Class.forName("ohos.system.version.SystemVersion");
+            Method method = clz.getMethod("getVersion");
+            return (String) method.invoke(clz);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return "Unknown";
+    }
+    
+}


### PR DESCRIPTION
鸿蒙虽然已经出来一段时间了，但似乎用的还是 EMUI 的信息，所以按常规方法获取的话还是会判定为 EMUI

这里添加了通过反射获取鸿蒙的方法，真机测试通过，方法来源是[这里](https://developer.huawei.com/consumer/cn/forum/topic/0201622701208270096?fid=0101587866109860105) 

![Screenshot_20210913_143018_com walkud rom checker app](https://user-images.githubusercontent.com/7713080/133034762-45a602a5-1cc9-46ea-99c0-530c70cb3af1.jpg)

